### PR TITLE
Features/137005159/add cancel order option fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 *.seed
 *.sublime-project
 *.sublime-workspace
-
+.vscode
 jsdoc.json
 lib-cov
 logs

--- a/imports/plugins/core/orders/client/templates/list/summary.html
+++ b/imports/plugins/core/orders/client/templates/list/summary.html
@@ -62,9 +62,34 @@
         {{/each}}
       </div>
     </div>
-    {{#if showCancelButton}}
-      <button name="cancel" class="btn btn-sm btn-danger flex-item-fill" type="submit" data-event-action="cancelOrder" data-i18n="order.cancelOrder">Cancel Order</button>
-    {{/if}}
-
+    
+   {{#if showCancelOrderForm}}
+     <div aria-labelledby="coreOrderCancelOrder" class="panel panel-default">
+       <div class="panel-heading">
+         <h3 class="panel-title">Cancel Order</h3>
+       </div>
+         <div class="panel-body">
+           <form name="cancelOrderForm" class="form-inline">
+             <div class="form-group {{hasError messages.errors.comment}}">
+               <label class="sr-only" for="comment">Select A Cancellation Reason:</label>
+               <select class="select-comment form-control" id="select-comment" name="select-comment">
+                 <option selected>-- Select A Cancellation Reason --</option>
+                 <option>Failed delivery</option>
+                 <option>Damaged Item</option>
+                 <option>Wrong Item</option>
+                 <option>Customer Changed Mind</option>
+               </select>
+                 {{#if hasError messages.errors.comment}}
+                   <span class="help-block">
+                     {{messages.errors.comment.reason}}
+                   </span>
+                 {{/if}}
+               </div>
+             <button class="btn btn-danger" type="submit" data-event-action="cancelOrder">Cancel Order</button>
+           </form>
+         </div>
+     </div>
+   {{/if}}
+    
   </div>
 </template>

--- a/imports/plugins/core/orders/client/templates/list/summary.html
+++ b/imports/plugins/core/orders/client/templates/list/summary.html
@@ -74,9 +74,7 @@
                <label class="sr-only" for="comment">Select A Cancellation Reason:</label>
                <select class="select-comment form-control" id="select-comment" name="select-comment">
                  <option selected>-- Select A Cancellation Reason --</option>
-                 <option>Failed delivery</option>
-                 <option>Damaged Item</option>
-                 <option>Wrong Item</option>
+                 <option>Late Delivery</option>
                  <option>Customer Changed Mind</option>
                </select>
                  {{#if hasError messages.errors.comment}}

--- a/imports/plugins/core/orders/client/templates/list/summary.js
+++ b/imports/plugins/core/orders/client/templates/list/summary.js
@@ -1,10 +1,10 @@
 import { Template } from "meteor/templating";
-import { Logger } from "/client/api";
 import { NumericInput } from "/imports/plugins/core/ui/client/components";
+import { Reaction } from "/client/api";
 
 Template.ordersListSummary.onCreated(function () {
   this.state = new ReactiveDict();
-
+  this.formMessages = new ReactiveVar({});
   this.autorun(() => {
     const currentData = Template.currentData();
     const order = currentData.order;
@@ -33,9 +33,26 @@ Template.ordersListSummary.helpers({
     };
   },
 
-  showCancelButton() {
+  showCancelOrderForm() {
+    if (Reaction.hasPermission("createProduct")) {
+      return false;
+    }
     return !(this.order.workflow.status === "canceled"
     || this.order.workflow.status === "coreOrderWorkflow/completed");
+  },
+
+  messages() {
+    return Template.instance().formMessages.get();
+  },
+
+  hasError(error) {
+    // True here means the field is valid
+    // We're checking if theres some other message to display
+    if (error !== true && typeof error !== "undefined") {
+      return "has-error has-feedback";
+    }
+
+    return false;
   }
 });
 
@@ -46,14 +63,62 @@ Template.ordersListSummary.events({
   /**
    * Submit form
    * @param  {Event} event - Event object
-   * @param  {Template} instance - Blaze Template
+   * @param  {Template} template - Blaze Template
    * @return {void}
    */
-  "click button[name=cancel]"(event, instance) {
-    event.stopPropagation();
+  "submit form[name=cancelOrderForm]"(event, template) {
+    event.preventDefault();
+    const validateComment = (comment) => {
+      check(comment, Match.OptionalOrNull(String));
+      const reasons = [
+        "Failed delivery",
+        "Damaged Item",
+        "Wrong Item",
+        "Customer Changed Mind"
+      ];
+      // Valid
+      if (reasons.includes(comment)) {
+        return true;
+      }
 
-    const state = instance.state;
+      // Invalid
+      return {
+        error: "INVALID_COMMENT",
+        reason: "Please select a reason for cancellation."
+      };
+    };
+
+    const commentInput = template.$(".select-comment");
+
+    const comment = commentInput.val().trim();
+    const validatedComment = validateComment(comment);
+
+    const templateInstance = Template.instance();
+    const errors = {};
+
+    templateInstance.formMessages.set({});
+
+    if (validatedComment !== true) {
+      errors.comment = validatedComment;
+    }
+
+    if ($.isEmptyObject(errors) === false) {
+      templateInstance.formMessages.set({
+        errors: errors
+      });
+      // prevent order cancel
+      return;
+    }
+
+    const newComment = {
+      body: comment,
+      userId: Meteor.userId(),
+      updatedAt: new Date
+    };
+
+    const state = template.state;
     const order = state.get("order");
+    order.comments = newComment;
 
     Alerts.alert({
       title: "Are you sure you want to cancel this order.",
@@ -61,11 +126,7 @@ Template.ordersListSummary.events({
       confirmButtonText: "Cancel Order"
     }, (isConfirm) => {
       if (isConfirm) {
-        Meteor.call("orders/cancelOrder", order, (error) => {
-          if (error) {
-            Logger.warn(error);
-          }
-        });
+        Meteor.call("orders/cancelOrder", order, newComment);
       }
     });
   }

--- a/imports/plugins/core/orders/client/templates/list/summary.js
+++ b/imports/plugins/core/orders/client/templates/list/summary.js
@@ -71,9 +71,7 @@ Template.ordersListSummary.events({
     const validateComment = (comment) => {
       check(comment, Match.OptionalOrNull(String));
       const reasons = [
-        "Failed delivery",
-        "Damaged Item",
-        "Wrong Item",
+        "Late Delivery",
         "Customer Changed Mind"
       ];
       // Valid

--- a/imports/plugins/core/orders/client/templates/orders.html
+++ b/imports/plugins/core/orders/client/templates/orders.html
@@ -75,6 +75,8 @@
       Tracking: <a href="#">{{shipmentTracking}}</a> - 
       <span class="badge badge-{{shipmentStatus.status}}">{{shipmentStatus.label}}</span>
     </p>
+    <p>Order Status: {{orderStatus}}</p>
+    <p>{{orderComments}}</p>
   </div>
 </template>
 

--- a/imports/plugins/core/orders/client/templates/orders.js
+++ b/imports/plugins/core/orders/client/templates/orders.js
@@ -298,7 +298,12 @@ Template.orderStatusDetail.helpers({
   orderAge: function () {
     return moment(this.createdAt).fromNow();
   },
-
+  orderStatus: function () {
+    return this.workflow.status;
+  },
+  orderComments() {
+    return this.comments ? `Reason: ${this.comments[0].body}` : "";
+  },
   shipmentTracking: function () {
     if (this.shipping[0].tracking) {
       return this.shipping[0].tracking;

--- a/imports/plugins/core/orders/client/templates/workflow/cancelOrder.html
+++ b/imports/plugins/core/orders/client/templates/workflow/cancelOrder.html
@@ -7,8 +7,15 @@
     <div class="panel-body">
       <form name="cancelOrderForm">
         <div class="form-group {{hasError messages.errors.comment}}">
-          <label>Reason</label>
-          <textarea name="comment" class="form-control input-comment"></textarea>
+          <label class="sr-only" for="comment">Reason</label>
+          <select class="input-comment form-control" id="input-comment" name="comment">
+            <option selected>-- Select A Cancellation Reason --</option>
+            <option>Item Out Of Stock</option>
+            <option>Item Damaged</option>
+            <option>Shipping Type Unavailable</option>
+            <option>Cannot Ship To Location</option>
+            <option>Customer Changed Mind</option>
+          </select>
           {{#if hasError messages.errors.comment}}
             <span class="help-block">
               {{messages.errors.comment.reason}}

--- a/imports/plugins/core/orders/client/templates/workflow/cancelOrder.js
+++ b/imports/plugins/core/orders/client/templates/workflow/cancelOrder.js
@@ -1,21 +1,6 @@
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
 
-const validateComment = (comment) => {
-  check(comment, Match.OptionalOrNull(String));
-
-  // Valid
-  if (comment.length >= 10) {
-    return true;
-  }
-
-  // Invalid
-  return {
-    error: "INVALID_COMMENT",
-    reason: "The reason must be at least 10 characters long."
-  };
-};
-
 Template.coreOrderCancelOrder.onCreated(function () {
   const template = Template.instance();
 
@@ -38,6 +23,27 @@ Template.coreOrderCancelOrder.onCreated(function () {
 Template.coreOrderCancelOrder.events({
   "submit form[name=cancelOrderForm]"(event, template) {
     event.preventDefault();
+
+    const validateComment = (comment) => {
+      check(comment, Match.OptionalOrNull(String));
+      const reasons = [
+        " Item Out Of Stock",
+        "Item Damaged",
+        "Shipping Type Unavailable",
+        "Cannot Ship To Location",
+        "Customer Changed Mind"
+      ];
+      // Valid
+      if (reasons.includes(comment)) {
+        return true;
+      }
+
+      // Invalid
+      return {
+        error: "INVALID_COMMENT",
+        reason: "Please select a reason for cancellation."
+      };
+    };
 
     const commentInput = template.$(".input-comment");
 

--- a/imports/plugins/core/orders/client/templates/workflow/cancelOrder.js
+++ b/imports/plugins/core/orders/client/templates/workflow/cancelOrder.js
@@ -77,7 +77,7 @@ Template.coreOrderCancelOrder.events({
       confirmButtonText: "Cancel Order"
     }, (isConfirm) => {
       if (isConfirm) {
-        Meteor.call("orders/vendorCancelOrder", order, newComment, (error) => {
+        Meteor.call("orders/cancelOrder", order, newComment, (error) => {
           if (!error) {
             template.showCancelOrderForm.set(false);
           }

--- a/lib/collections/schemas/orders.js
+++ b/lib/collections/schemas/orders.js
@@ -53,7 +53,8 @@ export const Notes = new SimpleSchema({
  */
 export const Comments = new SimpleSchema({
   body: {
-    type: String
+    type: String,
+    defaultValue: "customer cancelled order"
   },
   userId: {
     type: String

--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -177,24 +177,6 @@ Meteor.methods({
     });
   },
 
-/**
-   * orders/cancelOrder
-   *
-   * @summary Cancel an Order
-   * @param {Object} order - order object
-   * @return {Object} return update result
-   */
-  "orders/cancelOrder"(order) {
-    check(order, Object);
-    const orderId = order._id;
-    Orders.update(orderId, {
-      $set: { "workflow.status": "canceled" },
-      $addToSet: { "workflow.workflow": "coreOrderWorkflow/canceled" }
-    });
-
-    return Meteor.call("wallet/refund", order);
-  },
-
   /**
    * orders/vendorCancelOrder
    *
@@ -203,13 +185,9 @@ Meteor.methods({
    * @param {Object} newComment - new comment object
    * @return {Object} return update result
    */
-  "orders/vendorCancelOrder"(order, newComment) {
+  "orders/cancelOrder"(order, newComment) {
     check(order, Object);
     check(newComment, Object);
-
-    if (!Reaction.hasPermission("orders")) {
-      throw new Meteor.Error(403, "Access Denied");
-    }
 
     Orders.update(order._id, {
       $set: { "workflow.status": "canceled" },


### PR DESCRIPTION
### What does this PR do?
The PR fixes the cancel order feature bugs.
### Description of Task to be completed?
Allow customers to specify cancellation reason selecting from default reasons in a select dropdown
Allow  order admins to see order status on order list page.
Allow order admins to see order comments for cancelled orders .
### What are the relevant pivotal tracker stories?
#137005159 Add cancel order option

### Screenshots (if appropriate)
![oc](https://cloud.githubusercontent.com/assets/23452630/22786371/8bb6ba80-eed8-11e6-9519-3557e435756e.png)
